### PR TITLE
tighten restriction on training slash

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -286,11 +286,7 @@ export function decorateLinks(block) {
       }
 
       const url = new URL(link.href);
-      console.log(url.hostname);
       const isExternal = !/^(volvotrucks\.ca|\w+\.hlx\.(page|live)|localhost)$/.test(url.hostname);
-      /* const isExternal = !url.host.match('volvotrucks.ca')
-        && !url.host.match(/\.hlx.(page|live)/)
-        && !url.host.startsWith('localhost'); */
       const useNewWindow = url.host.match(/build\.volvotrucks\.(us|ca)/)
         || url.pathname.endsWith('.pdf')
         || url.pathname.endsWith('.jpeg')
@@ -300,7 +296,6 @@ export function decorateLinks(block) {
         link.target = '_blank';
       }
       // This removes the trailing slash from old links.
-      // if (url.host.match(/volvotrucks\.ca|localhost/) || url.host.match('.hlx.(page|live)')) {
       if (!isExternal) {
         link.href = link.href.replace(/\/$/, '');
       }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -286,7 +286,8 @@ export function decorateLinks(block) {
       }
 
       const url = new URL(link.href);
-      const isExternal = !/^((.*\.)?volvotrucks\.ca|\w+\.hlx\.(page|live)|localhost)$/.test(url.hostname);
+      const isExternal = !/^((.*\.)?(volvotrucks\.ca|\w+\.hlx\.(page|live))|localhost)$/.test(url.hostname);
+      console.log(isExternal);
       const useNewWindow = url.hostname.match(/build\.volvotrucks\.(us|ca)/)
         || url.pathname.endsWith('.pdf')
         || url.pathname.endsWith('.jpeg')

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -287,7 +287,6 @@ export function decorateLinks(block) {
 
       const url = new URL(link.href);
       const isExternal = !/^(.*\.)?volvotrucks\.ca$|^.*\.hlx\.(page|live)$|^localhost$/.test(url.hostname);
-      console.log(isExternal);
       const useNewWindow = url.hostname.match(/build\.volvotrucks\.(us|ca)/)
         || url.pathname.endsWith('.pdf')
         || url.pathname.endsWith('.jpeg')

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -286,7 +286,7 @@ export function decorateLinks(block) {
       }
 
       const url = new URL(link.href);
-      const isExternal = !/^((.*\.)?(volvotrucks\.ca|\w+\.hlx\.(page|live))|localhost)$/.test(url.hostname);
+      const isExternal = !/^(.*\.)?volvotrucks\.ca$|^.*\.hlx\.(page|live)$|^localhost$/.test(url.hostname);
       console.log(isExternal);
       const useNewWindow = url.hostname.match(/build\.volvotrucks\.(us|ca)/)
         || url.pathname.endsWith('.pdf')

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -286,9 +286,10 @@ export function decorateLinks(block) {
       }
 
       const url = new URL(link.href);
-      const isExternal = !url.host.startsWith('volvotrucks.ca')
+      const isExternal = !/^(volvotrucks\.ca|\w+\.hlx\.(page|live)|localhost)$/.test(url.hostname);
+      /* const isExternal = !url.host.match('volvotrucks.ca')
         && !url.host.match(/\.hlx.(page|live)/)
-        && !url.host.startsWith('localhost');
+        && !url.host.startsWith('localhost'); */
       const useNewWindow = url.host.match(/build\.volvotrucks\.(us|ca)/)
         || url.pathname.endsWith('.pdf')
         || url.pathname.endsWith('.jpeg')

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -286,11 +286,19 @@ export function decorateLinks(block) {
       }
 
       const url = new URL(link.href);
-      const external = !url.host.match('volvotrucks.ca') && !url.host.match('.hlx.(page|live)') && !url.host.match('localhost');
-      if (url.host.match('build.volvotrucks.(us|ca)') || url.pathname.endsWith('.pdf') || url.pathname.endsWith('.jpeg') || external) {
+      const isExternal = !url.host.startsWith('volvotrucks.ca')
+        && !url.host.match(/\.hlx.(page|live)/)
+        && !url.host.startsWith('localhost');
+      const useNewWindow = url.host.match(/build\.volvotrucks\.(us|ca)/)
+        || url.pathname.endsWith('.pdf')
+        || url.pathname.endsWith('.jpeg')
+        || isExternal;
+
+      if (useNewWindow) {
         link.target = '_blank';
       }
-      if (!external) {
+      // This removes the trailing slash from old links.
+      if (url.host.match(/volvotrucks\.ca|localhost/) || url.host.match('.hlx.(page|live)')) {
         link.href = link.href.replace(/\/$/, '');
       }
     });

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -286,6 +286,7 @@ export function decorateLinks(block) {
       }
 
       const url = new URL(link.href);
+      console.log(url.hostname);
       const isExternal = !/^(volvotrucks\.ca|\w+\.hlx\.(page|live)|localhost)$/.test(url.hostname);
       /* const isExternal = !url.host.match('volvotrucks.ca')
         && !url.host.match(/\.hlx.(page|live)/)

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -286,7 +286,7 @@ export function decorateLinks(block) {
       }
 
       const url = new URL(link.href);
-      const isExternal = !/^((.*\.)volvotrucks\.ca|\w+\.hlx\.(page|live)|localhost)$/.test(url.hostname);
+      const isExternal = !/^((.*\.)?volvotrucks\.ca|\w+\.hlx\.(page|live)|localhost)$/.test(url.hostname);
       const useNewWindow = url.hostname.match(/build\.volvotrucks\.(us|ca)/)
         || url.pathname.endsWith('.pdf')
         || url.pathname.endsWith('.jpeg')

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -299,7 +299,8 @@ export function decorateLinks(block) {
         link.target = '_blank';
       }
       // This removes the trailing slash from old links.
-      if (url.host.match(/volvotrucks\.ca|localhost/) || url.host.match('.hlx.(page|live)')) {
+      // if (url.host.match(/volvotrucks\.ca|localhost/) || url.host.match('.hlx.(page|live)')) {
+      if (!isExternal) {
         link.href = link.href.replace(/\/$/, '');
       }
     });

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -286,8 +286,8 @@ export function decorateLinks(block) {
       }
 
       const url = new URL(link.href);
-      const isExternal = !/^(volvotrucks\.ca|\w+\.hlx\.(page|live)|localhost)$/.test(url.hostname);
-      const useNewWindow = url.host.match(/build\.volvotrucks\.(us|ca)/)
+      const isExternal = !/^((.*\.)volvotrucks\.ca|\w+\.hlx\.(page|live)|localhost)$/.test(url.hostname);
+      const useNewWindow = url.hostname.match(/build\.volvotrucks\.(us|ca)/)
         || url.pathname.endsWith('.pdf')
         || url.pathname.endsWith('.jpeg')
         || isExternal;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Test URLs:
- Before: https://main--vg-volvotrucks-ca--hlxsites.hlx.page/en-ca/trucks/vnr-electric
- After: https://trailing-slash-fix--vg-volvotrucks-ca--hlxsites.hlx.page/en-ca/trucks/vnr-electric

Hover over links in the document. All internal links should not have a trailing slash.
External links should have `target="_blank"`.