### PR TITLE
remove max-height

### DIFF
--- a/blocks/specifications/specifications.css
+++ b/blocks/specifications/specifications.css
@@ -11,7 +11,6 @@
 .block.specifications img {
     display: block;
     margin: 0 auto;
-    max-height: 68px;
 }
 
 .block.specifications p:last-child {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #23 

Test URLs:
- Before: https://main--vg-volvotrucks-ca--hlxsites.hlx.page/en-ca/trucks/vah/specifications
- After: https://specs-block-css--vg-volvotrucks-ca--hlxsites.hlx.page/en-ca/trucks/vah/specifications

This corrects the aspect ratio of the small images on top of the Specifications table. Corrects both languages.
You can easily check the other trucks by changing the truck name in the URL:
- vnr-electric
- vnr
- vnl
- vnx
- vhd
- vah
